### PR TITLE
pinentry: Handle percent-encoded responses

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2018"
 [dependencies]
 log = "0.4"
 nom = "5"
+percent-encoding = "2.1"
 secrecy = "0.6"
 which = { version = "3.1", default-features = false }
 zeroize = "1"

--- a/src/assuan.rs
+++ b/src/assuan.rs
@@ -1,6 +1,7 @@
 use log::{debug, info};
 use percent_encoding::percent_decode_str;
 use secrecy::{ExposeSecret, SecretString};
+use std::borrow::Cow;
 use std::io::{self, BufRead, BufReader, Write};
 use std::path::Path;
 use std::process::{ChildStdin, ChildStdout};
@@ -122,6 +123,9 @@ impl Connection {
                     let data_line_decoded =
                         percent_decode_str(data_line.expose_secret()).decode_utf8()?;
                     data = Some(buf.unwrap_or_else(String::new) + &data_line_decoded);
+                    if let Cow::Owned(mut data_line_decoded) = data_line_decoded {
+                        data_line_decoded.zeroize();
+                    }
                 }
                 res => info!("< {:?}", res),
             }

--- a/src/assuan.rs
+++ b/src/assuan.rs
@@ -1,4 +1,5 @@
 use log::{debug, info};
+use percent_encoding::percent_decode_str;
 use secrecy::{ExposeSecret, SecretString};
 use std::io::{self, BufRead, BufReader, Write};
 use std::path::Path;
@@ -118,7 +119,9 @@ impl Connection {
                 Response::Comment(comment) => debug!("< # {}", comment),
                 Response::DataLine(data_line) => {
                     let buf = data.take();
-                    data = Some(buf.unwrap_or_else(String::new) + data_line.expose_secret());
+                    let data_line_decoded =
+                        percent_decode_str(data_line.expose_secret()).decode_utf8()?;
+                    data = Some(buf.unwrap_or_else(String::new) + &data_line_decoded);
                 }
                 res => info!("< {:?}", res),
             }

--- a/src/error.rs
+++ b/src/error.rs
@@ -57,6 +57,9 @@ pub enum Error {
     Io(io::Error),
     /// An uncommon or unexpected GPG error.
     Gpg(GpgError),
+
+    /// The user's passphrase doesn't decode to valid UTF-8.
+    Encoding(std::str::Utf8Error),
 }
 
 impl fmt::Display for Error {
@@ -66,6 +69,7 @@ impl fmt::Display for Error {
             Error::Cancelled => write!(f, "Operation cancelled"),
             Error::Gpg(e) => e.fmt(f),
             Error::Io(e) => e.fmt(f),
+            Error::Encoding(e) => e.fmt(f),
         }
     }
 }
@@ -73,6 +77,12 @@ impl fmt::Display for Error {
 impl From<io::Error> for Error {
     fn from(e: io::Error) -> Self {
         Error::Io(e)
+    }
+}
+
+impl From<std::str::Utf8Error> for Error {
+    fn from(e: std::str::Utf8Error) -> Self {
+        Error::Encoding(e)
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -58,7 +58,7 @@ pub enum Error {
     /// An uncommon or unexpected GPG error.
     Gpg(GpgError),
 
-    /// The user's passphrase doesn't decode to valid UTF-8.
+    /// The user's input doesn't decode to valid UTF-8.
     Encoding(std::str::Utf8Error),
 }
 


### PR DESCRIPTION
Here's my attempt at fixing the issue identified in #1.

It uses the [`percent-encoding`](https://github.com/servo/rust-url/) crate, which appears to be relatively popular (and is maintained by the Servo team).

Fixes #1.