### PR TITLE
`secrecy 0.8`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.44.0
+          toolchain: 1.51.0
           override: true
 
       # Ensure all code has been formatted with rustfmt
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.44.0
+          toolchain: 1.51.0
           override: true
       - name: cargo fetch
         uses: actions-rs/cargo@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to Rust's notion of
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html). All versions prior
 to 1.0.0 are beta releases.
 
+## [Unreleased]
+- MSRV has been increased to 1.51.0
+
 ## [0.3.0] - 2021-01-11
 - MSRV has been increased to 1.44.0
 - Bumped `nom` crate to 0.6

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,6 @@ edition = "2018"
 log = "0.4"
 nom = { version = "6", default-features = false }
 percent-encoding = "2.1"
-secrecy = "0.7"
+secrecy = "0.8"
 which = { version = "4", default-features = false }
 zeroize = "1"

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ pinentry = "0.3"
 
 See the [documentation](https://docs.rs/pinentry) for examples.
 
-`pinentry` requires Rust version 1.44 or greater.
+`pinentry` requires Rust version 1.51 or greater.
 
 ## License
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,7 @@
 //! ```
 
 // Catch documentation errors caused by code changes.
-#![deny(intra_doc_link_resolution_failure)]
+#![deny(broken_intra_doc_links)]
 #![deny(missing_docs)]
 
 use secrecy::SecretString;


### PR DESCRIPTION
Requires MSRV bump to 1.51.