### PR TITLE
UNIX specific methods to set the tty / GUI output

### DIFF
--- a/src/assuan.rs
+++ b/src/assuan.rs
@@ -108,10 +108,19 @@ impl Connection {
         // only set the environment variables if they are provided - if no variables are explicitly
         // provided, they will be inherited from the parent process.
         if let Some(xorg_display) = options.xorg_display {
-            command.env("DISPLAY", xorg_display);
+            // if variable is empty, clearly no display is wanted
+            if xorg_display.is_empty() {
+                command.env_remove("DISPLAY");
+            } else {
+                command.env("DISPLAY", xorg_display);
+            }
         }
         if let Some(wayland_display) = options.wayland_display {
-            command.env("WAYLAND_DISPLAY", wayland_display);
+            if wayland_display.is_empty() {
+                command.env_remove("WAYLAND_DISPLAY");
+            } else {
+                command.env("WAYLAND_DISPLAY", wayland_display);
+            }
         }
 
         let process = command.spawn()?;


### PR DESCRIPTION
Hi, thanks for the great bindings! While using them, I needed an option to force pinentry to use a specific TTY / specific X-Server / no GUI at all, so I created some methods to do this.

This PR introduces the `UnixOptions` struct to allow for setting the TTY, TTY type, X.Org server (env variable `DISPLAY`)  and the Wayland server (env variable `WAYLAND_DISPLAY`) on UNIX systems. All UNIX-specific features are `cfg(unix)` gated.