### PR TITLE
Improve child process handling on connection close

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,12 +9,13 @@ keywords = ["passphrase", "password"]
 categories = ["api-bindings", "command-line-interface"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.81"
 
 [dependencies]
 log = "0.4"
 nom = { version = "7", default-features = false }
 percent-encoding = "2.1"
 secrecy = "0.10"
+wait-timeout = "0.2.1"
 which = { version = "4", default-features = false }
 zeroize = "1"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.60.0"
+channel = "1.81.0"
 components = ["clippy", "rustfmt"]


### PR DESCRIPTION
Hi,

  `Connection::open()` drops the `Child` process handle after invoking `std::process::Command::new()`, which leads to the creation of zombie processes in long-running programs.

  This fixes the issue by waiting on the child after acknowledging the BYE, giving it one second to terminate properly before killing it.

 This adds a dependency to [`wait-timeout`](https://crates.io/crates/wait-timeout), which unfortunately bumps the MSRV to 1.82.
  
 If the MSRV change or extra dependency are unacceptable, please consider accepting #16 instead.